### PR TITLE
Adding Just Ape subecosystem & org

### DIFF
--- a/data/ecosystems/s/solana.toml
+++ b/data/ecosystems/s/solana.toml
@@ -121,6 +121,7 @@ sub_ecosystems = [
   "Jet Protocol",
   "Jito Network",
   "Jupiter Exchange",
+  "Just Ape","
   "Kurobi",
   "Kyber Network",
   "kycDAO",
@@ -320,6 +321,7 @@ github_organizations = [
   "https://github.com/firedancer-io",
   "https://github.com/generatus",
   "https://github.com/hashblock",
+  "https://github.com/Just-Ape-Studios",
   "https://github.com/magiceden-oss",
   "https://github.com/Nebula-Wallet",
   "https://github.com/phantom-labs",


### PR DESCRIPTION
This PR aims to add all Just Ape-related GitHub links and name to solana.toml